### PR TITLE
feat: add optional debug logging

### DIFF
--- a/PixerUpload/Program.cs
+++ b/PixerUpload/Program.cs
@@ -1,12 +1,17 @@
 ﻿using Microsoft.Extensions.Logging;
 using PixerUpload;
 using PixerUpload.Pixer;
+using System.Linq;
+
+// Handle command line arguments
+var argsList = args.ToList();
+var debugMode = argsList.Remove("--debug");
 
 // Configure logging
 using var loggerFactory = LoggerFactory.Create(builder =>
     builder
         .AddConsole()
-        .SetMinimumLevel(LogLevel.Debug)
+        .SetMinimumLevel(debugMode ? LogLevel.Debug : LogLevel.Information)
 );
 
 var logger = loggerFactory.CreateLogger<Program>();
@@ -33,7 +38,7 @@ try
     logger.LogInformation("Firmware upgrade check completed.");
 
     // Get image path from command line arguments
-    var imagePath = args.Length > 0 ? args[^1] : "image.png";
+    var imagePath = argsList.FirstOrDefault() ?? "image.png";
 
     // check image path
     if (!File.Exists(imagePath))

--- a/electron/index.html
+++ b/electron/index.html
@@ -11,6 +11,9 @@
         <header>
             <h1>🖼️ Pixer Upload Tool</h1>
             <p>將圖片上傳到您的 Pixer 裝置</p>
+            <div class="debug-toggle">
+                <label><input type="checkbox" id="debugToggle"> 顯示 Debug Log</label>
+            </div>
         </header>
 
         <main>

--- a/electron/main.js
+++ b/electron/main.js
@@ -117,7 +117,7 @@ ipcMain.handle('select-image', async () => {
 });
 
 // IPC 處理程序：檢查裝置狀態
-ipcMain.handle('check-device', async () => {
+ipcMain.handle('check-device', async (event, debug) => {
   return new Promise((resolve, reject) => {
     try {
       const executablePath = getExecutablePath();
@@ -125,7 +125,10 @@ ipcMain.handle('check-device', async () => {
       console.log('執行檔路徑:', executablePath);
       console.log('工作目錄:', workingDir);
       
-      const child = spawn(executablePath, [], {
+      const args = [];
+      if (debug) args.push('--debug');
+
+      const child = spawn(executablePath, args, {
         cwd: workingDir
       });
       
@@ -176,7 +179,7 @@ ipcMain.handle('check-device', async () => {
 });
 
 // IPC 處理程序：上傳圖片
-ipcMain.handle('upload-image', async (event, imagePath) => {
+ipcMain.handle('upload-image', async (event, imagePath, debug) => {
   return new Promise((resolve, reject) => {
     try {
       const executablePath = getExecutablePath();
@@ -184,8 +187,12 @@ ipcMain.handle('upload-image', async (event, imagePath) => {
       console.log('上傳圖片 - 執行檔路徑:', executablePath);
       console.log('上傳圖片 - 工作目錄:', workingDir);
       console.log('上傳圖片 - 圖片路徑:', imagePath);
-      
-      const child = spawn(executablePath, [imagePath], {
+
+      const args = [];
+      if (debug) args.push('--debug');
+      args.push(imagePath);
+
+      const child = spawn(executablePath, args, {
         cwd: workingDir
       });
       

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -12,15 +12,15 @@ try {
     },
     
     // 檢查裝置狀態
-    checkDevice: () => {
+    checkDevice: (debug) => {
       console.log('checkDevice called');
-      return ipcRenderer.invoke('check-device');
+      return ipcRenderer.invoke('check-device', debug);
     },
     
     // 上傳圖片
-    uploadImage: (imagePath) => {
-      console.log('uploadImage called with:', imagePath);
-      return ipcRenderer.invoke('upload-image', imagePath);
+    uploadImage: (imagePath, debug) => {
+      console.log('uploadImage called with:', imagePath, 'debug:', debug);
+      return ipcRenderer.invoke('upload-image', imagePath, debug);
     },
     
     // 獲取系統資訊

--- a/electron/renderer.js
+++ b/electron/renderer.js
@@ -12,9 +12,11 @@ const uploadResult = document.getElementById('uploadResult');
 const resultContent = document.getElementById('resultContent');
 const deviceStatus = document.getElementById('deviceStatus');
 const systemInfo = document.getElementById('systemInfo');
+const debugToggle = document.getElementById('debugToggle');
 
 // 全域變數
 let selectedImagePath = null;
+let debugEnabled = debugToggle?.checked || false;
 
 // 初始化應用程式
 async function initApp() {
@@ -63,11 +65,18 @@ function setupEventListeners() {
     
     // 檢查裝置按鈕
     if (checkDeviceBtn) checkDeviceBtn.addEventListener('click', checkDevice);
-    
+
     // 監聽上傳進度
     if (window.electronAPI && window.electronAPI.onUploadProgress) {
         window.electronAPI.onUploadProgress((data) => {
             appendProgressText(data);
+        });
+    }
+
+    // Debug 開關
+    if (debugToggle) {
+        debugToggle.addEventListener('change', () => {
+            debugEnabled = debugToggle.checked;
         });
     }
 }
@@ -150,7 +159,7 @@ async function checkDevice() {
         setButtonLoading(checkDeviceBtn, true);
         if (deviceStatus) deviceStatus.innerHTML = '<p class="status-idle">檢查中...</p>';
         
-        const result = await window.electronAPI.checkDevice();
+        const result = await window.electronAPI.checkDevice(debugEnabled);
         
         if (deviceStatus) {
             if (result.success) {
@@ -189,7 +198,7 @@ async function uploadImage() {
         if (progressText) progressText.textContent = '開始上傳...\n';
         hideElement(uploadResult);
         
-        const result = await window.electronAPI.uploadImage(selectedImagePath);
+        const result = await window.electronAPI.uploadImage(selectedImagePath, debugEnabled);
         
         // 顯示結果
         showElement(uploadResult);

--- a/electron/style.css
+++ b/electron/style.css
@@ -39,6 +39,16 @@ header p {
     opacity: 0.9;
 }
 
+.debug-toggle {
+    margin-top: 10px;
+    color: white;
+    font-size: 0.9em;
+}
+
+.debug-toggle input {
+    margin-right: 5px;
+}
+
 /* 主要內容區域 */
 main {
     flex: 1;


### PR DESCRIPTION
## Summary
- show only info-level logs by default
- add UI toggle to enable debug logs
- plumb debug flag from renderer to backend and .NET app

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bfe35ce810832597cbf76cbe9c4251